### PR TITLE
Add support for hook supporting encrypted btrfs root filesystems

### DIFF
--- a/hook/crypt.hook
+++ b/hook/crypt.hook
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+build_hook() {
+	add_binary cryptsetup
+	add_binary dmsetup
+	add_binary lvm
+
+	add_module dm_mod
+
+	add_file /lib/udev/rules.d/10-dm.rules
+	add_file /lib/udev/rules.d/13-dm-disk.rules
+	add_file /lib/udev/rules.d/69-dm-lvm-metad.rules
+	add_file /lib/udev/rules.d/95-dm-notify.rules
+	add_file /lib/udev/rules.d/11-dm-lvm.rules
+	add_file /lib/udev/rules.d/64-btrfs-dm.rules
+
+	add_file /usr/lib/libgcc_s.so.1
+	add_file /usr/lib/libgcc_s.so
+}
+

--- a/init.in
+++ b/init.in
@@ -53,13 +53,21 @@ parse_cmdline() {
 		LABEL=*) eval $root; device="/dev/disk/by-label/$LABEL" ;;
 	esac
 }
-	
+
+
+mount_crypt() {
+	test -f /sbin/cryptsetup && /sbin/cryptsetup luksOpen $device venom
+	test -f /sbin/lvm && lvm vgchange -ay --sysinit
+	test -f /sbin/cryptsetup && device=/dev/dm-1
+}
+
 mount_root() {
 	newroot=$1
 	if [ ! "$device" ]; then
 		echo "device not scpecified!"
 		shell
 	fi
+	mount_crypt
 	if ! mount -n ${rootfstype:+-t $rootfstype} -o ${rwopt:-ro}${rootflags:+,$rootflags} "$device" "$newroot" ; then
 		echo "cant mount: $device"
 		shell
@@ -88,8 +96,14 @@ run_hook() {
 mount_handler=mount_root
 init=/sbin/init
 rootfstype=auto
+CONSOLE=/dev/tty1
 
 mount_setup
+
+# take control of tty1 and disable output from spamming console
+exec >${CONSOLE} <${CONSOLE} 2>&1
+echo 1 > /proc/sys/kernel/printk
+
 parse_cmdline
 run_hook early
 


### PR DESCRIPTION
I couldn't do it all within the hook because i need to type the password into the console.

I'm assuming the encrypted filesystem once mounted will go to /dev/dm-1. I know gentoo has some more sophisticated way of finding the root filesystem but I'm not sure how this assumption would ever be wrong.

I didn't add support for if you encrypted using a key. And i didn't test other filesystems or encryption methods. But I think if you used a common filesystem like ext3/4, it should also just work.

And obviously if a user does not add the crypt hook to their /etc/mkinitramfs.conf, this should have no effect.