### PR TITLE
Add hook supporting encrypted root filesystems

### DIFF
--- a/hook/encrypt.hook
+++ b/hook/encrypt.hook
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+build_hook() {
+	add_binary cryptsetup
+	add_binary dmsetup
+	add_binary lvm
+	
+	add_binary stty
+	add_binary expr
+	
+	add_module dm_mod
+
+	add_file /lib/udev/rules.d/10-dm.rules
+	add_file /lib/udev/rules.d/11-dm-lvm.rules
+	add_file /lib/udev/rules.d/13-dm-disk.rules
+	add_file /lib/udev/rules.d/69-dm-lvm-metad.rules
+	add_file /lib/udev/rules.d/95-dm-notify.rules
+	add_file /lib/udev/rules.d/64-btrfs-dm.rules
+
+	add_file /usr/lib/libgcc_s.so.1
+	add_file /usr/lib/libgcc_s.so
+}
+
+run_earlyhook() {
+	modprobe dm_mod
+	sleep 2	
+	CONSOLE=/dev/tty1
+	TRIES=0
+	SUCCESS=0
+	while [ "$TRIES" -lt 3 ] && [ "$SUCCESS" -eq 0 ]
+	do
+		echo -n "Enter passphrase for $device: "	
+		stty_orig=$(stty -F $CONSOLE -g)
+		stty -F $CONSOLE -echo
+		read inputvariable <> $CONSOLE
+		stty -F $CONSOLE $stty_orig
+		echo
+		echo -n $inputvariable | cryptsetup open --type luks $device venom - > /dev/null && SUCCESS=1
+		inputvariable=
+		TRIES=`expr $TRIES + 1`
+	done
+	
+	/sbin/lvm vgchange -ay --sysinit
+	device=/dev/dm-1
+}


### PR DESCRIPTION
This is a much better implementation than I had the first go around. I didn't see an encrypt hook for mkinitcpio until I found it inside the cryptsetup package from Arch, and I used that for some inspiration.

I was able to keep it all within the hook, and I also was able to code in limited retries and a failure will fall back to console properly.

This doesn't have support for those who would like to use a key to unlock their encrypted root partition.

I only tested on my setup which is a luks encrypted btrfs root filesystem, but i believe ext3/4 should also work.
